### PR TITLE
Add env for switching gpt models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 OPENAI_API_KEY=""
 # https://rollbar.com/signup/
 ROLLBAR_ACCESS_TOKEN=""
+
+# gpt-3.5-turbo or gpt-4
+OPENAI_GPT_MODEL=""

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,5 @@
 OPENAI_API_KEY=""
 # https://rollbar.com/signup/
 ROLLBAR_ACCESS_TOKEN=""
-
 # gpt-3.5-turbo or gpt-4
-OPENAI_GPT_MODEL=""
+OPENAI_GPT_MODEL="gpt-4"

--- a/src/utils/chat-gpt.ts
+++ b/src/utils/chat-gpt.ts
@@ -7,7 +7,6 @@ import { stringifyJSON } from './utils.js';
 export const OPENAI_CHAT_ENDPOINT =
     'https://api.openai.com/v1/chat/completions';
 
-
 export const OPENAI_GPT_MODEL = process.env.OPENAI_GPT_MODEL ?? 'gpt-4';
 
 export const OPENAI_CONFIG = {
@@ -15,7 +14,7 @@ export const OPENAI_CONFIG = {
     // Adjust this value (0 to 1) to control randomness. Lower values make the output more deterministic.
     // https://platform.openai.com/docs/guides/gpt/how-should-i-set-the-temperature-parameter
     temperature: 0.2,
-}
+};
 
 async function askGPTChat(messages, debug) {
     const noEvents = { events: [] };
@@ -29,9 +28,7 @@ async function askGPTChat(messages, debug) {
             logger.info(stringifyJSON(messages));
             logger.info('');
             logger.info('-----OpenAI Config-----');
-            logger.info(
-                stringifyJSON(OPENAI_CONFIG),
-            );
+            logger.info(stringifyJSON(OPENAI_CONFIG));
         }
 
         const openai = new OpenAI({
@@ -39,7 +36,7 @@ async function askGPTChat(messages, debug) {
         });
         const chatCompletion = await openai.chat.completions.create({
             messages,
-            ...OPENAI_CONFIG
+            ...OPENAI_CONFIG,
         });
         const response = chatCompletion.choices?.[0]?.message?.content?.trim();
 

--- a/src/utils/chat-gpt.ts
+++ b/src/utils/chat-gpt.ts
@@ -18,13 +18,22 @@ async function askGPTChat(messages, debug) {
             logger.info('-----Question-----');
             logger.info(stringifyJSON(messages));
             logger.info('');
+            logger.info('-----OpenAI Config-----');
+            logger.info(
+                stringifyJSON({
+                    model: process.env.GPT_MODEL ?? 'gpt-4',
+                    // Adjust this value (0 to 1) to control randomness. Lower values make the output more deterministic.
+                    // https://platform.openai.com/docs/guides/gpt/how-should-i-set-the-temperature-parameter
+                    temperature: 0.2,
+                }),
+            );
         }
 
         const openai = new OpenAI({
             apiKey: process.env.OPENAI_API_KEY,
         });
         const chatCompletion = await openai.chat.completions.create({
-            model: 'gpt-4',
+            model: process.env.GPT_MODEL ?? 'gpt-4',
             messages,
             // Adjust this value (0 to 1) to control randomness. Lower values make the output more deterministic.
             // https://platform.openai.com/docs/guides/gpt/how-should-i-set-the-temperature-parameter

--- a/src/utils/chat-gpt.ts
+++ b/src/utils/chat-gpt.ts
@@ -7,6 +7,16 @@ import { stringifyJSON } from './utils.js';
 export const OPENAI_CHAT_ENDPOINT =
     'https://api.openai.com/v1/chat/completions';
 
+
+export const OPENAI_GPT_MODEL = process.env.OPENAI_GPT_MODEL ?? 'gpt-4';
+
+export const OPENAI_CONFIG = {
+    model: OPENAI_GPT_MODEL,
+    // Adjust this value (0 to 1) to control randomness. Lower values make the output more deterministic.
+    // https://platform.openai.com/docs/guides/gpt/how-should-i-set-the-temperature-parameter
+    temperature: 0.2,
+}
+
 async function askGPTChat(messages, debug) {
     const noEvents = { events: [] };
     try {
@@ -20,12 +30,7 @@ async function askGPTChat(messages, debug) {
             logger.info('');
             logger.info('-----OpenAI Config-----');
             logger.info(
-                stringifyJSON({
-                    model: process.env.GPT_MODEL ?? 'gpt-4',
-                    // Adjust this value (0 to 1) to control randomness. Lower values make the output more deterministic.
-                    // https://platform.openai.com/docs/guides/gpt/how-should-i-set-the-temperature-parameter
-                    temperature: 0.2,
-                }),
+                stringifyJSON(OPENAI_CONFIG),
             );
         }
 
@@ -33,11 +38,8 @@ async function askGPTChat(messages, debug) {
             apiKey: process.env.OPENAI_API_KEY,
         });
         const chatCompletion = await openai.chat.completions.create({
-            model: process.env.GPT_MODEL ?? 'gpt-4',
             messages,
-            // Adjust this value (0 to 1) to control randomness. Lower values make the output more deterministic.
-            // https://platform.openai.com/docs/guides/gpt/how-should-i-set-the-temperature-parameter
-            temperature: 0.2,
+            ...OPENAI_CONFIG
         });
         const response = chatCompletion.choices?.[0]?.message?.content?.trim();
 


### PR DESCRIPTION
## Issue

- I added env to switch gpt models if the user doesnt provide any env by default it will use gpt-4 model
- I added OpenAI config info to the logger

Resolves #41 

## Testing Steps

1. I tested with gpt-3.5 turbo with no changes to the prompt it worked properly and fetched all the monster,habitat & dates info
